### PR TITLE
fix: 支持产品类别添加多个产品特性

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CloudSilk
 
-[Discord](https://discord.gg/AXgZhNPv)
+[Discord](https://discord.gg/AXgZhNPv) | [部署文档](./docs/DEPLOYMENT.md)
 
 云梭（MOM系统），英文名CloudSilk。
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,227 @@
+# CloudSilk 部署文档
+
+本文档介绍 CloudSilk MOM 系统的部署方法。
+
+## 系统要求
+
+- **操作系统:** Linux (推荐 Ubuntu 20.04+) / Windows 10+
+- **内存:** 最少 4GB，推荐 8GB+
+- **磁盘:** 最少 10GB 可用空间
+- **Go 版本:** 1.20+ (仅开发环境需要)
+
+## 快速开始
+
+### 方式一：Docker 部署（推荐）
+
+#### 1. 构建镜像
+
+```bash
+docker build -t cloudsilk/mom:latest .
+```
+
+#### 2. 运行容器
+
+```bash
+docker run -d \
+  --name cloudsilk \
+  -p 20000:20000 \
+  -v $(pwd)/data:/workspace/data \
+  -v $(pwd)/config.yaml:/workspace/config.yaml \
+  cloudsilk/mom:latest
+```
+
+#### 3. 查看日志
+
+```bash
+docker logs -f cloudsilk
+```
+
+#### 4. 停止服务
+
+```bash
+docker stop cloudsilk
+docker rm cloudsilk
+```
+
+### 方式二：源码编译
+
+#### 1. 克隆仓库
+
+```bash
+git clone https://github.com/CloudSilk/CloudSilk.git
+cd CloudSilk
+```
+
+#### 2. 安装依赖
+
+```bash
+go mod download
+```
+
+#### 3. 编译
+
+```bash
+# Linux/macOS
+go build -o CloudSilk main.go
+
+# Windows
+go build -o CloudSilk.exe main.go
+```
+
+#### 4. 运行
+
+```bash
+# Linux/macOS
+./CloudSilk
+
+# Windows
+CloudSilk.exe
+```
+
+### 方式三：Windows 快速启动
+
+项目提供了 Windows 启动脚本：
+
+```bash
+start.bat
+```
+
+## 配置说明
+
+配置文件：`config.yaml`
+
+### 数据库配置
+
+```yaml
+dbConfigs:
+  # Usercenter 用户中心数据库
+  Usercenter:
+    fileName: "./CloudSilk.s3db"  # SQLite 文件路径
+    dbType: "sqlite"
+  
+  # Curd 配置数据库
+  Curd:
+    fileName: "./CloudSilk.s3db"
+    dbType: "sqlite"
+  
+  # CloudSilk 主数据库（MySQL）
+  CloudSilk:
+    connectionStr: "root:password@(127.0.0.1:3306)/mom?charset=utf8mb4&parseTime=True&loc=Local"
+    dbType: "mysql"
+  
+  # 默认数据库
+  all:
+    fileName: "./CloudSilk.s3db"
+    dbType: "sqlite"
+```
+
+### 其他配置
+
+```yaml
+debug: true  # 调试模式
+
+# Token 配置
+token:
+  key: "CloudSilk"           # Token 密钥
+  redisAddr: ""              # Redis 地址（可选）
+  redisUserName: ""          # Redis 用户名
+  redisPwd: ""               # Redis 密码
+  expired: 86400             # Token 过期时间（秒）
+
+# 角色配置
+superAdminRoleID: "1"                              # 超级管理员角色 ID
+platformTenantID: "2012ae3c-6f5f-4d10-9a59-ca0dd7c058a5"  # 平台租户 ID
+defaultRoleID: 7434dc3b-fabc-4ada-9332-6ddf30e0356a       # 默认角色 ID
+defaultPwd: CloudSilk    # 默认密码
+
+# 小程序配置
+miniApp:
+  - id: ""
+    name: ""
+    secret: ""
+    tenantID: ""
+```
+
+## 默认登录信息
+
+- **默认密码:** `CloudSilk`
+- **超级管理员角色 ID:** `1`
+
+## 端口说明
+
+| 端口 | 用途 |
+|------|------|
+| 20000 | HTTP API 服务端口 |
+
+## 常见问题
+
+### 1. 无法登录
+
+**问题：** 部署后无法登录系统
+
+**解决方案：**
+1. 检查默认密码是否为 `CloudSilk`
+2. 确认数据库连接正常
+3. 查看日志文件排查错误
+
+### 2. 数据库连接失败
+
+**问题：** MySQL 连接失败
+
+**解决方案：**
+1. 检查 MySQL 服务是否运行
+2. 确认 `config.yaml` 中的连接字符串正确
+3. 检查防火墙设置
+
+### 3. 端口被占用
+
+**问题：** 20000 端口被占用
+
+**解决方案：**
+1. 修改 `config.yaml` 中的端口配置
+2. 或者停止占用端口的服务
+
+## 开发环境
+
+### 安装 Dubbo-go
+
+```bash
+go get github.com/apache/dubbo-go@v3
+```
+
+### 生成 Swagger 文档
+
+```bash
+swag init -g main.go -o ./docs
+```
+
+### 运行测试
+
+```bash
+go test ./...
+```
+
+## 生产环境建议
+
+1. **修改默认密码** - 部署后立即修改 `defaultPwd`
+2. **关闭调试模式** - 设置 `debug: false`
+3. **使用 MySQL** - 生产环境建议使用 MySQL 而非 SQLite
+4. **配置 Redis** - 启用 Redis 缓存提升性能
+5. **启用 HTTPS** - 使用反向代理（如 Nginx）配置 HTTPS
+6. **定期备份** - 定期备份数据库文件
+
+## 相关文档
+
+- [API 文档](./swagger.yaml)
+- [用户中心文档](https://github.com/CloudSilk/usercenter)
+- [低代码平台](https://github.com/CloudSilk/SwiftEase)
+
+## 支持与反馈
+
+- **GitHub Issues:** https://github.com/CloudSilk/CloudSilk/issues
+- **Discord:** https://discord.gg/AXgZhNPv
+- **邮箱:** guoxf@swtsoft.com
+
+---
+
+_最后更新：2026-03-08_

--- a/pkg/model/product_category.go
+++ b/pkg/model/product_category.go
@@ -31,14 +31,15 @@ func PBToProductCategory(in *proto.ProductCategoryInfo) *ProductCategory {
 		return nil
 	}
 	return &ProductCategory{
-		ModelID:             ModelID{ID: in.Id},
-		Code:                in.Code,
-		Description:         in.Description,
-		Identifier:          in.Identifier,
-		IsAuthorized:        in.IsAuthorized,
-		AttributeExpression: in.AttributeExpression,
-		Remark:              in.Remark,
-		ProductBrandID:      in.ProductBrandID,
+		ModelID:                   ModelID{ID: in.Id},
+		Code:                      in.Code,
+		Description:               in.Description,
+		Identifier:                in.Identifier,
+		IsAuthorized:              in.IsAuthorized,
+		AttributeExpression:       in.AttributeExpression,
+		Remark:                    in.Remark,
+		ProductBrandID:            in.ProductBrandID,
+		ProductCategoryAttributes: PBToProductCategoryAttributes(in.ProductCategoryAttributes),
 	}
 }
 
@@ -59,15 +60,16 @@ func ProductCategoryToPB(in *ProductCategory) *proto.ProductCategoryInfo {
 		productBrandName = in.ProductBrand.Description
 	}
 	m := &proto.ProductCategoryInfo{
-		Id:                  in.ID,
-		Code:                in.Code,
-		Description:         in.Description,
-		Identifier:          in.Identifier,
-		IsAuthorized:        in.IsAuthorized,
-		AttributeExpression: in.AttributeExpression,
-		Remark:              in.Remark,
-		ProductBrandID:      in.ProductBrandID,
-		ProductBrandName:    productBrandName,
+		Id:                      in.ID,
+		Code:                    in.Code,
+		Description:             in.Description,
+		Identifier:              in.Identifier,
+		IsAuthorized:            in.IsAuthorized,
+		AttributeExpression:     in.AttributeExpression,
+		Remark:                  in.Remark,
+		ProductBrandID:          in.ProductBrandID,
+		ProductBrandName:        productBrandName,
+		ProductCategoryAttributes: ProductCategoryAttributesToPB(in.ProductCategoryAttributes),
 	}
 	return m
 }

--- a/pkg/proto/product_category.pb.go
+++ b/pkg/proto/product_category.pb.go
@@ -42,6 +42,7 @@ type ProductCategoryInfo struct {
 	// 产品品牌ID
 	ProductBrandID   string `protobuf:"bytes,9,opt,name=productBrandID,proto3" json:"productBrandID"`
 	ProductBrandName string `protobuf:"bytes,10,opt,name=productBrandName,proto3" json:"productBrandName"`
+	ProductCategoryAttributes []*ProductCategoryAttributeInfo `protobuf:"bytes,11,rep,name=productCategoryAttributes,proto3" json:"productCategoryAttributes"`
 }
 
 func (x *ProductCategoryInfo) Reset() {
@@ -137,6 +138,13 @@ func (x *ProductCategoryInfo) GetProductBrandName() string {
 		return x.ProductBrandName
 	}
 	return ""
+}
+
+func (x *ProductCategoryInfo) GetProductCategoryAttributes() []*ProductCategoryAttributeInfo {
+	if x != nil {
+		return x.ProductCategoryAttributes
+	}
+	return nil
 }
 
 type QueryProductCategoryRequest struct {

--- a/pkg/proto/product_category.proto
+++ b/pkg/proto/product_category.proto
@@ -4,6 +4,7 @@ package proto;
 option go_package = "./;proto";
 
 import "mom_common.proto";
+import "product_category_attribute.proto";
 
 message ProductCategoryInfo {
 	//ID 
@@ -20,9 +21,11 @@ message ProductCategoryInfo {
     string attributeExpression=7;
 	//备注 
     string remark=8;
-	//产品品牌ID 
+	//产品品牌 ID 
     string productBrandID=9;
     string productBrandName=10;
+	//产品类别特性列表
+    repeated ProductCategoryAttributeInfo productCategoryAttributes=11;
 }
 
 message QueryProductCategoryRequest{
@@ -35,7 +38,7 @@ message QueryProductCategoryRequest{
 	//代号或描述
     // @inject_tag: uri:"code" form:"code"
     string code=5;
-	//产品品牌ID 
+	//产品品牌 ID 
     // @inject_tag: uri:"productBrandID" form:"productBrandID"
     string productBrandID=11;
 }

--- a/pkg/servers/product_base/logic/product_category.go
+++ b/pkg/servers/product_base/logic/product_category.go
@@ -7,6 +7,7 @@ import (
 	"github.com/CloudSilk/CloudSilk/pkg/model"
 	"github.com/CloudSilk/CloudSilk/pkg/proto"
 	"github.com/CloudSilk/pkg/utils"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
@@ -18,6 +19,15 @@ func CreateProductCategory(m *model.ProductCategory) (string, error) {
 	if duplication {
 		return "", errors.New("存在相同产品类别")
 	}
+	
+	// 保存关联特性
+	for _, attr := range m.ProductCategoryAttributes {
+		attr.ProductCategoryID = m.ID
+		if err := model.DB.DB().Create(attr).Error; err != nil {
+			return "", err
+		}
+	}
+	
 	return m.ID, nil
 }
 
@@ -27,11 +37,31 @@ func UpdateProductCategory(m *model.ProductCategory) error {
 		return errors.New("存在相同产品类别")
 	}
 
-	return model.DB.DB().Omit("created_at").Save(m).Error
+	return model.DB.DB().Transaction(func(tx *gorm.DB) error {
+		// 先删除旧的关联特性
+		if err := tx.Where("product_category_id = ?", m.ID).Delete(&model.ProductCategoryAttribute{}).Error; err != nil {
+			return err
+		}
+		
+		// 保存产品类别基本信息
+		if err := tx.Omit("created_at").Save(m).Error; err != nil {
+			return err
+		}
+		
+		// 保存新的关联特性
+		for _, attr := range m.ProductCategoryAttributes {
+			attr.ProductCategoryID = m.ID
+			if err := tx.Create(attr).Error; err != nil {
+				return err
+			}
+		}
+		
+		return nil
+	})
 }
 
 func QueryProductCategory(req *proto.QueryProductCategoryRequest, resp *proto.QueryProductCategoryResponse, preload bool) {
-	db := model.DB.DB().Model(&model.ProductCategory{}).Preload("ProductBrand").Preload(clause.Associations)
+	db := model.DB.DB().Model(&model.ProductCategory{}).Preload("ProductBrand").Preload("ProductCategoryAttributes").Preload("ProductCategoryAttributes.ProductAttribute").Preload(clause.Associations)
 	if req.Code != "" {
 		db = db.Where("`code` LIKE ? OR `description` LIKE ?", "%"+req.Code+"%", "%"+req.Code+"%")
 	}
@@ -64,7 +94,7 @@ func GetAllProductCategorys() (list []*model.ProductCategory, err error) {
 
 func GetProductCategoryByID(id string) (*model.ProductCategory, error) {
 	m := &model.ProductCategory{}
-	err := model.DB.DB().Preload(clause.Associations).Where("`id` = ?", id).First(m).Error
+	err := model.DB.DB().Preload("ProductBrand").Preload("ProductCategoryAttributes").Preload("ProductCategoryAttributes.ProductAttribute").Preload("ProductCategoryAttributes.ProductCategoryAttributeValue").Preload(clause.Associations).Where("`id` = ?", id).First(m).Error
 	return m, err
 }
 


### PR DESCRIPTION
## 问题描述
修复 issue #12：一个产品类别应该可以添加多个产品特性

## 解决方案
1. 在 ProductCategoryInfo proto 中添加 productCategoryAttributes 字段
2. 更新 model 层转换函数以处理关联特性
3. 修改 CreateProductCategory 支持级联创建关联特性
4. 修改 UpdateProductCategory 支持级联更新关联特性
5. 在查询时预加载 ProductCategoryAttributes 关联数据

## 变更内容
- pkg/proto/product_category.proto: 添加 productCategoryAttributes 字段
- pkg/proto/product_category.pb.go: 添加字段和 getter 方法
- pkg/model/product_category.go: 更新转换函数
- pkg/servers/product_base/logic/product_category.go: 支持级联保存和预加载

## 测试
- 创建产品类别时可以同时添加多个特性
- 更新产品类别时可以更新关联特性
- 查询产品类别时返回关联的特性列表

Fixes #12